### PR TITLE
v1.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ These are the supported API resources:
 * Metadata
 * Snapshot
 * Team
-* Workd Diary
+* Work Diary
 * Activities
 
 # License

--- a/src/Upwork/API/AuthTypes/AbstractOAuth.php
+++ b/src/Upwork/API/AuthTypes/AbstractOAuth.php
@@ -145,9 +145,9 @@ abstract class AbstractOAuth
                 header('Location: ' . $authUrl);
             } elseif (self::$_mode === 'nonweb') {
                 // authorize nonweb application
-                ApiDebug::p('found [nonweb] mode, need to autorize application manually');
+                ApiDebug::p('found [nonweb] mode, need to authorize application manually');
 
-                $prompt = 'Visit ' . $authUrl . "\n" .
+                $prompt = 'Visit ' . $authUrl . "\n " .
                     'and provide oauth_verifier for further authorization' . "\n" .
                     '$ ';
                 if (PHP_OS == 'WINNT') {


### PR DESCRIPTION
- fix a typo in the README
- Readline ignores \n - add space between authorization URL and the second part of the promt